### PR TITLE
Add English version for CSL file

### DIFF
--- a/ipb_en.csl
+++ b/ipb_en.csl
@@ -1,0 +1,666 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Modified by: Benny Istanto/KLI/G2501222008, bennyistanto@apps.ipb.ac.id -->
+<!-- English version available on: https://gist.github.com/bennyistanto/ef6b1a2bb1ed303a7832f789ac7e7a70 -->
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
+  <!-- changed default-locale to en-US -->
+  <info>
+    <title>Institut Pertanian Bogor: Pedoman Penulisan Karya Ilmiah Edisi ke-4 (English)</title>
+    <!-- updated title -->
+    <title-short>IPB PPKI 4</title-short>
+    <id>http://www.zotero.org/styles/institut-pertanian-bogor</id>
+    <link href="http://www.zotero.org/styles/institut-pertanian-bogor" rel="self"/>
+    <link href="http://www.zotero.org/styles/apa" rel="template"/>
+    <link href="http://ppki.staff.ipb.ac.id/unduhan/" rel="documentation"/>
+    <link href="https://drive.google.com/file/d/0B0YEuQotqd_BQVpkR0lHNHctSHM/view" rel="documentation"/>
+    <author>
+      <name>Auriza Rahmad Akbar</name>
+      <email>auriza.akbar@gmail.com</email>
+    </author>
+    <author>
+      <name>M. Rachmatarramadhan</name>
+      <email>rachmatarramadhan@gmail.com</email>
+    </author>
+    <category citation-format="author-date"/>
+    <category field="science"/>
+    <summary>IPB PPKI 4 style, Name-Year system: author-date in text, sorted in alphabetical order by author.</summary>
+    <updated>2022-01-02T01:47:37+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="en">
+    <style-options punctuation-in-quote="true"/>
+    <date form="text">
+      <date-part name="day" suffix=" "/>
+      <date-part name="month" suffix=" "/>
+      <date-part name="year"/>
+    </date>
+    <date form="numeric">
+      <date-part name="day" form="numeric-leading-zeros" suffix="-"/>
+      <date-part name="month" form="numeric-leading-zeros" suffix="-"/>
+      <date-part name="year"/>
+    </date>
+    <terms>
+      <term name="accessed">accessed</term>
+      <!-- changed "diunduh" to "accessed" -->
+      <term name="and">and</term>
+      <!-- changed "dan" to "and" -->
+      <term name="and others">and others</term>
+      <!-- changed "dan lainnya" to "and others" -->
+      <term name="anonymous">anonymous</term>
+      <!-- changed "anonim" to "anonymous" -->
+      <term name="anonymous" form="short">anon.</term>
+      <term name="on">on</term>
+      <!-- changed "pada" to "on" -->
+      <term name="available at">available at</term>
+      <!-- changed "tersedia pada" to "available at" -->
+      <term name="by">by</term>
+      <term name="circa">circa</term>
+      <term name="circa" form="short">c.</term>
+      <term name="cited">cited</term>
+      <!-- changed "dikutip" to "cited" -->
+      <term name="edition">
+        <single>edition</single>
+        <!-- changed "edisi" to "edition" -->
+        <multiple>editions</multiple>
+        <!-- changed "edisi" to "editions" -->
+      </term>
+      <term name="edition" form="short">ed</term>
+      <term name="et-al">et al.</term>
+      <term name="forthcoming">forthcoming</term>
+      <!-- changed "mendatang" to "forthcoming" -->
+      <term name="from">from</term>
+      <!-- changed "dari" to "from" -->
+      <term name="ibid">ibid.</term>
+      <term name="in">in</term>
+      <!-- changed "di dalam" to "in" -->
+      <term name="in press">in press</term>
+      <!-- changed "di dalam press" to "in press" -->
+      <term name="internet">internet</term>
+      <term name="interview">interview</term>
+      <!-- changed "wawancara" to "interview" -->
+      <term name="letter">letter</term>
+      <!-- changed "surat" to "letter" -->
+      <term name="no date">no date</term>
+      <!-- changed "tanpa tanggal" to "no date" -->
+      <term name="no date" form="short">n.d.</term>
+      <term name="online">online</term>
+      <!-- changed "daring" to "online" -->
+      <term name="presented at">presented at</term>
+      <!-- changed "dipresentasikan pada" to "presented at" -->
+      <term name="reference">
+        <single>reference</single>
+        <multiple>references</multiple>
+      </term>
+      <term name="reference" form="short">
+        <single>ref.</single>
+        <multiple>ref.</multiple>
+      </term>
+      <term name="retrieved">retrieved</term>
+      <!-- changed "diambil" to "retrieved" -->
+      <term name="scale">scale</term>
+      <!-- changed "skala" to "scale" -->
+      <term name="version">version</term>
+      <!-- changed "versi" to "version" -->
+      <term name="ad">AD</term>
+      <!-- changed "M" to "AD" -->
+      <term name="bc">BC</term>
+      <!-- changed "SM" to "BC" -->
+      <term name="open-quote">“</term>
+      <term name="close-quote">”</term>
+      <term name="open-inner-quote">‘</term>
+      <term name="close-inner-quote">’</term>
+      <term name="page-range-delimiter">&#8211;</term>
+      <term name="ordinal"/>
+      <term name="ordinal-01"/>
+      <term name="ordinal-02"/>
+      <term name="ordinal-03"/>
+      <term name="ordinal-11"/>
+      <term name="ordinal-12"/>
+      <term name="ordinal-13"/>
+      <term name="long-ordinal-01">first</term>
+      <!-- changed "pertama" to "first" -->
+      <term name="long-ordinal-02">second</term>
+      <!-- changed "kedua" to "second" -->
+      <term name="long-ordinal-03">third</term>
+      <!-- changed "ketiga" to "third" -->
+      <term name="long-ordinal-04">fourth</term>
+      <!-- changed "keempat" to "fourth" -->
+      <term name="long-ordinal-05">fifth</term>
+      <!-- changed "kelima" to "fifth" -->
+      <term name="long-ordinal-06">sixth</term>
+      <!-- changed "keenam" to "sixth" -->
+      <term name="long-ordinal-07">seventh</term>
+      <!-- changed "ketujuh" to "seventh" -->
+      <term name="long-ordinal-08">eighth</term>
+      <!-- changed "kedelapan" to "eighth" -->
+      <term name="long-ordinal-09">ninth</term>
+      <!-- changed "kesembilan" to "ninth" -->
+      <term name="long-ordinal-10">tenth</term>
+      <!-- changed "kesepuluh" to "tenth" -->
+      <term name="book">
+        <single>book</single>
+        <!-- changed "buku" to "book" -->
+        <multiple>books</multiple>
+        <!-- changed "buku" to "books" -->
+      </term>
+      <term name="chapter">
+        <single>chapter</single>
+        <!-- changed "bab" to "chapter" -->
+        <multiple>chapters</multiple>
+        <!-- changed "bab" to "chapters" -->
+      </term>
+      <term name="column">
+        <single>column</single>
+        <!-- changed "kolom" to "column" -->
+        <multiple>columns</multiple>
+        <!-- changed "kolom" to "columns" -->
+      </term>
+      <term name="figure">
+        <single>figure</single>
+        <!-- changed "gambar" to "figure" -->
+        <multiple>figures</multiple>
+        <!-- changed "gambar" to "figures" -->
+      </term>
+      <term name="folio">
+        <single>folio</single>
+        <multiple>folios</multiple>
+      </term>
+      <term name="issue">
+        <single>issue</single>
+        <!-- changed "nomor" to "issue" -->
+        <multiple>issues</multiple>
+        <!-- changed "nomor" to "issues" -->
+      </term>
+      <term name="line">
+        <single>line</single>
+        <!-- changed "baris" to "line" -->
+        <multiple>lines</multiple>
+        <!-- changed "baris" to "lines" -->
+      </term>
+      <term name="note">
+        <single>note</single>
+        <!-- changed "catatan" to "note" -->
+        <multiple>notes</multiple>
+        <!-- changed "catatan" to "notes" -->
+      </term>
+      <term name="opus">
+        <single>opus</single>
+        <multiple>opera</multiple>
+      </term>
+      <term name="page">
+        <single>page</single>
+        <!-- changed "halaman" to "page" -->
+        <multiple>pages</multiple>
+        <!-- changed "halaman" to "pages" -->
+      </term>
+      <term name="number-of-pages">
+        <single>page</single>
+        <!-- changed "halaman" to "page" -->
+        <multiple>pages</multiple>
+        <!-- changed "halaman" to "pages" -->
+      </term>
+      <term name="paragraph">
+        <single>paragraph</single>
+        <!-- changed "paragraf" to "paragraph" -->
+        <multiple>paragraphs</multiple>
+        <!-- changed "paragraf" to "paragraphs" -->
+      </term>
+      <term name="part">
+        <single>part</single>
+        <!-- changed "bagian" to "part" -->
+        <multiple>parts</multiple>
+        <!-- changed "bagian" to "parts" -->
+      </term>
+      <term name="section">
+        <single>section</single>
+        <multiple>sections</multiple>
+      </term>
+      <term name="sub-verbo">
+        <single>sub verbo</single>
+        <multiple>sub verbis</multiple>
+      </term>
+      <term name="verse">
+        <single>verse</single>
+        <!-- changed "ayat" to "verse" -->
+        <multiple>verses</multiple>
+        <!-- changed "ayat" to "verses" -->
+      </term>
+      <term name="volume">
+        <single>volume</single>
+        <multiple>volumes</multiple>
+      </term>
+      <term name="book" form="short">bk.</term>
+      <term name="chapter" form="short">chap.</term>
+      <term name="column" form="short">col.</term>
+      <term name="figure" form="short">fig.</term>
+      <!-- changed "gam." to "fig." -->
+      <term name="folio" form="short">f.</term>
+      <term name="issue" form="short">no.</term>
+      <term name="line" form="short">l.</term>
+      <term name="note" form="short">n.</term>
+      <term name="opus" form="short">op.</term>
+      <term name="page" form="short">
+        <single>p.</single>
+        <!-- changed "hlm." to "p." -->
+        <multiple>pp.</multiple>
+        <!-- changed "hlm." to "pp." -->
+      </term>
+      <term name="number-of-pages" form="short">
+        <single>p.</single>
+        <!-- changed "hlm." to "p." -->
+        <multiple>pp.</multiple>
+        <!-- changed "hlm." to "pp." -->
+      </term>
+      <term name="paragraph" form="short">para.</term>
+      <term name="part" form="short">pt.</term>
+      <term name="section" form="short">sec.</term>
+      <term name="sub-verbo" form="short">
+        <single>s.v.</single>
+        <multiple>s.vv.</multiple>
+      </term>
+      <term name="verse" form="short">
+        <single>v.</single>
+        <!-- changed "a." to "v." -->
+        <multiple>vv.</multiple>
+        <!-- changed "a." to "vv." -->
+      </term>
+      <term name="volume" form="short">
+        <single>vol.</single>
+        <multiple>vols.</multiple>
+      </term>
+      <term name="paragraph" form="symbol">
+        <single>¶</single>
+        <multiple>¶¶</multiple>
+      </term>
+      <term name="section" form="symbol">
+        <single>§</single>
+        <multiple>§§</multiple>
+      </term>
+      <term name="director">
+        <single>director</single>
+        <!-- changed "direktur" to "director" -->
+        <multiple>directors</multiple>
+        <!-- changed "direktur" to "directors" -->
+      </term>
+      <term name="editor">
+        <single>editor</single>
+        <multiple>editors</multiple>
+      </term>
+      <term name="editorial-director">
+        <single>editor</single>
+        <multiple>editors</multiple>
+      </term>
+      <term name="illustrator">
+        <single>illustrator</single>
+        <!-- changed "ilustrator" to "illustrator" -->
+        <multiple>illustrators</multiple>
+        <!-- changed "ilustrator" to "illustrators" -->
+      </term>
+      <term name="translator">
+        <single>translator</single>
+        <!-- changed "penerjemah" to "translator" -->
+        <multiple>translators</multiple>
+        <!-- changed "penerjemah" to "translators" -->
+      </term>
+      <term name="editortranslator">
+        <single>editor &amp; translator</single>
+        <!-- changed "editor & penerjemah" to "editor & translator" -->
+        <multiple>editors &amp; translators</multiple>
+        <!-- changed "editor & penerjemah" to "editors & translators" -->
+      </term>
+      <term name="director" form="short">
+        <single>dir.</single>
+        <multiple>dirs.</multiple>
+      </term>
+      <term name="editor" form="short">
+        <single>ed.</single>
+        <multiple>eds.</multiple>
+      </term>
+      <term name="editorial-director" form="short">
+        <single>ed.</single>
+        <multiple>eds.</multiple>
+      </term>
+      <term name="illustrator" form="short">
+        <single>ill.</single>
+        <!-- changed "il." to "ill." -->
+        <multiple>ills.</multiple>
+        <!-- changed "il." to "ills." -->
+      </term>
+      <term name="translator" form="short">
+        <single>trans.</single>
+        <!-- changed "penerj." to "trans." -->
+        <multiple>trans.</multiple>
+        <!-- changed "penerj." to "trans." -->
+      </term>
+      <term name="editortranslator" form="short">
+        <single>ed. &amp; trans.</single>
+        <!-- changed "ed. & penerjemah" to "ed. & trans." -->
+        <multiple>eds. &amp; trans.</multiple>
+        <!-- changed "ed. & penerjemah" to "eds. & trans." -->
+      </term>
+      <term name="container-author" form="verb">by</term>
+      <!-- changed "oleh" to "by" -->
+      <term name="director" form="verb">directed by</term>
+      <!-- changed "diarahkan oleh" to "directed by" -->
+      <term name="editor" form="verb">edited by</term>
+      <!-- changed "diedit oleh" to "edited by" -->
+      <term name="editorial-director" form="verb">edited by</term>
+      <!-- changed "diedit oleh" to "edited by" -->
+      <term name="illustrator" form="verb">illustrated by</term>
+      <!-- changed "diilustrasi oleh" to "illustrated by" -->
+      <term name="interviewer" form="verb">interview by</term>
+      <!-- changed "interview oleh" to "interview by" -->
+      <term name="recipient" form="verb">to</term>
+      <!-- changed "kepada" to "to" -->
+      <term name="reviewed-author" form="verb">by</term>
+      <!-- changed "oleh" to "by" -->
+      <term name="translator" form="verb">translated by</term>
+      <!-- changed "diterjemahkan oleh" to "translated by" -->
+      <term name="editortranslator" form="verb">edited &amp; translated by</term>
+      <!-- changed "disunting & diterjemahkan oleh" to "edited & translated by" -->
+      <term name="director" form="verb-short">dir. by</term>
+      <!-- changed "dir. oleh" to "dir. by" -->
+      <term name="editor" form="verb-short">ed. by</term>
+      <!-- changed "ed. oleh" to "ed. by" -->
+      <term name="editorial-director" form="verb-short">ed. by</term>
+      <!-- changed "ed. oleh" to "ed. by" -->
+      <term name="illustrator" form="verb-short">ill. by</term>
+      <!-- changed "illus. oleh" to "ill. by" -->
+      <term name="translator" form="verb-short">trans. by</term>
+      <!-- changed "trans. oleh" to "trans. by" -->
+      <term name="editortranslator" form="verb-short">ed. &amp; trans. by</term>
+      <!-- changed "ed. & trans. oleh" to "ed. & trans. by" -->
+      <term name="month-01">January</term>
+      <!-- changed "Januari" to "January" -->
+      <term name="month-02">February</term>
+      <!-- changed "Februari" to "February" -->
+      <term name="month-03">March</term>
+      <!-- changed "Maret" to "March" -->
+      <term name="month-04">April</term>
+      <!-- changed "April" to "April" -->
+      <term name="month-05">May</term>
+      <!-- changed "Mei" to "May" -->
+      <term name="month-06">June</term>
+      <!-- changed "Juni" to "June" -->
+      <term name="month-07">July</term>
+      <!-- changed "Juli" to "July" -->
+      <term name="month-08">August</term>
+      <!-- changed "Agustus" to "August" -->
+      <term name="month-09">September</term>
+      <!-- changed "September" to "September" -->
+      <term name="month-10">October</term>
+      <!-- changed "Oktober" to "October" -->
+      <term name="month-11">November</term>
+      <!-- changed "November" to "November" -->
+      <term name="month-12">December</term>
+      <!-- changed "Desember" to "December" -->
+      <term name="month-01" form="short">Jan</term>
+      <term name="month-02" form="short">Feb</term>
+      <term name="month-03" form="short">Mar</term>
+      <term name="month-04" form="short">Apr</term>
+      <term name="month-05" form="short">May</term>
+      <term name="month-06" form="short">Jun</term>
+      <term name="month-07" form="short">Jul</term>
+      <term name="month-08" form="short">Aug</term>
+      <!-- changed "Agu" to "Aug" -->
+      <term name="month-09" form="short">Sep</term>
+      <term name="month-10" form="short">Oct</term>
+      <term name="month-11" form="short">Nov</term>
+      <term name="month-12" form="short">Dec</term>
+      <term name="season-01">Spring</term>
+      <!-- changed "Semi" to "Spring" -->
+      <term name="season-02">Summer</term>
+      <!-- changed "Panas" to "Summer" -->
+      <term name="season-03">Autumn</term>
+      <!-- changed "Gugur" to "Autumn" -->
+      <term name="season-04">Winter</term>
+      <!-- changed "Dingin" to "Winter" -->
+    </terms>
+  </locale>
+  <macro name="editor">
+    <names variable="editor translator" delimiter="; " suffix=".">
+      <name delimiter=", " delimiter-precedes-last="always" initialize-with="" name-as-sort-order="all" sort-separator=" "/>
+      <label prefix=", "/>
+    </names>
+  </macro>
+  <macro name="author">
+    <names variable="author" delimiter=", ">
+      <name delimiter-precedes-last="always" initialize-with="" name-as-sort-order="all" sort-separator=" "/>
+      <et-al font-style="italic"/>
+      <label form="long" prefix=", " strip-periods="true"/>
+      <substitute>
+        <names variable="editor translator"/>
+        <text variable="title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" delimiter=", " initialize-with="." and="text"/>
+      <et-al font-style="italic"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text variable="title-short"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="review">
+    <group delimiter=". ">
+      <text variable="reviewed-title"/>
+      <text variable="container-title"/>
+    </group>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if variable="accessed" match="any">
+        <group delimiter=". ">
+          <group prefix=" [" suffix="]" delimiter=" ">
+            <text term="accessed"/>
+            <date variable="accessed" delimiter=" ">
+              <date-part name="year"/>
+              <date-part name="month" form="short" strip-periods="true"/>
+              <date-part name="day"/>
+            </date>
+          </group>
+          <text variable="URL" prefix="Available on: "/>
+          <!-- changed "Tersedia pada" to "Available on" -->
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="title">
+    <group delimiter=" ">
+      <choose>
+        <if type="book" match="all">
+          <text variable="title" text-case="title" font-style="italic"/>
+        </if>
+        <else>
+          <text variable="title"/>
+        </else>
+      </choose>
+      <choose>
+        <if type="thesis" match="any">
+          <text variable="genre" prefix="[" suffix="]."/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="publisher">
+    <group delimiter=": ">
+      <text variable="publisher-place"/>
+      <text variable="publisher" suffix="."/>
+    </group>
+  </macro>
+  <macro name="pages">
+    <group delimiter="; ">
+      <group>
+        <label variable="page" form="short" suffix=" " plural="never"/>
+        <text variable="page"/>
+      </group>
+      <group>
+        <text variable="number-of-pages"/>
+        <choose>
+          <if is-numeric="number-of-pages">
+            <label variable="number-of-pages" form="short" prefix=" " plural="never"/>
+          </if>
+        </choose>
+      </group>
+    </group>
+  </macro>
+  <macro name="year-date">
+    <group delimiter=" ">
+      <date variable="issued" delimiter=" ">
+        <date-part name="year"/>
+      </date>
+      <choose>
+        <if type="patent article-newspaper webpage" match="any">
+          <date variable="issued" delimiter=" ">
+            <date-part name="month" form="short" strip-periods="true"/>
+            <date-part name="day"/>
+          </date>
+        </if>
+        <else-if type="article-journal article-magazine" match="any">
+          <choose>
+            <if variable="volume issue" match="none">
+              <date variable="issued" delimiter=" ">
+                <date-part name="month" form="short" strip-periods="true"/>
+                <date-part name="day"/>
+              </date>
+            </if>
+          </choose>
+        </else-if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <text term="edition" form="short" text-case="title" strip-periods="false"/>
+          <number prefix="#" variable="edition" form="ordinal"/>
+          <!-- changed "ke-" to "#" -->
+        </group>
+      </if>
+      <else>
+        <text variable="edition" suffix="."/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="collection">
+    <choose>
+      <if type="report">
+        <group prefix=" " suffix="." delimiter=" ">
+          <text variable="collection-title"/>
+          <text variable="number" prefix=" Report No.: "/>
+        </group>
+      </if>
+      <else>
+        <group prefix=" (" suffix=")." delimiter=" ">
+          <names variable="collection-editor" suffix=". ">
+            <name delimiter-precedes-last="always" initialize-with="" name-as-sort-order="all" sort-separator=" "/>
+            <label prefix=", "/>
+          </names>
+          <text variable="collection-title"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
+    <sort>
+      <key macro="year-date"/>
+      <key macro="author-short"/>
+    </sort>
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=" ">
+        <text macro="author-short"/>
+        <text macro="year-date"/>
+      </group>
+      <text variable="locator" prefix=": "/>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="false" et-al-min="11" et-al-use-first="10">
+    <sort>
+      <key macro="author"/>
+      <key macro="year-date"/>
+    </sort>
+    <layout>
+      <group suffix="." delimiter=". ">
+        <text macro="author"/>
+        <text macro="year-date"/>
+        <text macro="title"/>
+      </group>
+      <group suffix=".">
+        <choose>
+          <if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
+            <group prefix=" " suffix="." delimiter=" ">
+              <text macro="edition"/>
+              <text variable="volume" prefix="Volume " suffix="."/>
+              <!-- changed "Volume ke-" to "Volume " -->
+              <text macro="editor" suffix="."/>
+            </group>
+            <text prefix=" " macro="publisher"/>
+            <text prefix=" " macro="collection"/>
+            <text variable="page" prefix="p. "/>
+            <!-- changed "hlm " to "p. " -->
+            <text variable="original-title" font-style="italic" prefix=" Translated from: " suffix="."/>
+            <!-- changed "Terjemahan dari: " to "Translated from: " -->
+            <text variable="note" prefix=" Ed. " suffix="."/>
+            <!-- changed " Ed ke-" to " Ed. " -->
+          </if>
+          <else-if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
+            <group prefix=" " delimiter=" " suffix=".">
+              <group delimiter=" ">
+                <text term="in" text-case="capitalize-first" suffix=":"/>
+                <text macro="editor" suffix="."/>
+                <text variable="container-title" text-case="title" font-style="italic" suffix="."/>
+                <choose>
+                  <if match="any" variable="accessed">
+                    <text term="internet" prefix="[" suffix="]"/>
+                  </if>
+                </choose>
+              </group>
+              <text variable="volume" prefix="Vol. " suffix="."/>
+              <text macro="edition"/>
+              <group suffix="." delimiter=". ">
+                <text variable="event" suffix=";" font-style="italic"/>
+                <text variable="event-place" suffix="."/>
+                <text macro="publisher"/>
+                <text prefix=" " macro="collection"/>
+                <text macro="pages"/>
+              </group>
+            </group>
+          </else-if>
+          <else-if type="review review-book" match="any">
+            <text macro="editor" prefix=" " suffix="[review]."/>
+            <!-- changed "ulasan" to "review" -->
+            <group prefix=" " suffix=".">
+              <text macro="review" suffix="."/>
+              <group prefix=" ">
+                <text variable="volume"/>
+                <text variable="issue" prefix="(" suffix=")"/>
+              </group>
+              <text variable="page" prefix=":"/>
+            </group>
+          </else-if>
+          <else-if type="personal_communication" match="any">
+            <text macro="editor" suffix="[personal communication]."/>
+            <!-- changed "komunikasi singkat" to "personal communication" -->
+          </else-if>
+          <else>
+            <text variable="original-title" prefix=" [" suffix="]."/>
+            <text macro="editor" prefix=" " suffix="[editorial]."/>
+            <group prefix=" " suffix=".">
+              <text variable="container-title" form="short" font-style="italic" suffix="."/>
+              <text variable="volume" prefix=" "/>
+              <text variable="issue" prefix="(" suffix=")"/>
+              <text variable="page" prefix=":"/>
+              <text variable="DOI" prefix=". doi:"/>
+              <!-- changed ".doi:" to ". doi:" -->
+            </group>
+          </else>
+        </choose>
+      </group>
+      <text prefix=" " macro="access"/>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
# IPB PPKI 4 style - English version

**Goal:** Students who are planning to write the report in English already have the official guideline from here: https://kmm.ipb.ac.id/ppki-edisi4-eng/. It would be good if the CSL file was also available in English.

Here is the modified **IPB Pedoman Penulisan Karya Ilmiah Edisi ke-4 (PPKI)** CSL file with the Bahasa Indonesia terms translated to English. The modifications include changing terms such as "dan" to "and", "diunduh" to "accessed", and so on. The modifications have been annotated for clarity. 

This version follows the [CSL 1.0.2 specification](https://docs.citationstyles.org/en/stable/specification.html). You can validate the file using any [CSL validator tool](https://validator.citationstyles.org/) to ensure compliance.

![Screenshot 2024-05-21 130742](https://github.com/auriza/csl-ipb/assets/722584/7ef8240e-bd9d-473a-a5c4-8001321beed7)

In summary, the following translations were made in the CSL file:

1. `dan` to `and`
2. `diunduh` to `accessed`
3. `dan lainnya` to `and others`
4. `anonim` to `anonymous`
5. `pada` to `on`
6. `tersedia pada` to `available on`
7. `dikutip` to `cited`
8. `edisi` to `edition`
9. `mendatang` to `forthcoming`
10. `dari` to `from`
11. `di dalam` to `in`
12. `di dalam press` to `in press`
13. `wawancara` to `interview`
14. `surat` to `letter`
15. `tanpa tanggal` to `no date`
16. `daring` to `online`
17. `dipresentasikan pada` to `presented at`
18. `diambil` to `retrieved`
19. `skala` to `scale`
20. `versi` to `version`
21. `M` to `AD`
22. `SM` to `BC`
23. `pertama` to `first`
24. `kedua` to `second`
25. `ketiga` to `third`
26. `keempat` to `fourth`
27. `kelima` to `fifth`
28. `keenam` to `sixth`
29. `ketujuh` to `seventh`
30. `kedelapan` to `eighth`
31. `kesembilan` to `ninth`
32. `kesepuluh` to `tenth`
33. `buku` to `book`
34. `bab` to `chapter`
35. `kolom` to `column`
36. `gambar` to `figure`
37. `nomor` to `issue`
38. `baris` to `line`
39. `catatan` to `note`
40. `halaman` to `page`
41. `paragraf` to `paragraph`
42. `bagian` to `part`
43. `ayat` to `verse`
44. `direktur` to `director`
45. `editor` to `editor`
46. `ilustrator` to `illustrator`
47. `penerjemah` to `translator`
48. `editor & penerjemah` to `editor & translator`
49. `oleh` to `by`
50. `diarahkan oleh` to `directed by`
51. `diedit oleh` to `edited by`
52. `diilustrasi oleh` to `illustrated by`
53. `interview oleh` to `interview by`
54. `kepada` to `to`
55. `diterjemahkan oleh` to `translated by`
56. `disunting & diterjemahkan oleh` to `edited & translated by`
57. `Januari` to `January`
58. `Februari` to `February`
59. `Maret` to `March`
60. `April` to `April`
61. `Mei` to `May`
62. `Juni` to `June`
63. `Juli` to `July`
64. `Agustus` to `August`
65. `September` to `September`
66. `Oktober` to `October`
67. `November` to `November`
68. `Desember` to `December`
69. `Agu` to `Aug`
70. `Semi` to `Spring`
71. `Panas` to `Summer`
72. `Gugur` to `Autumn`
73. `Dingin` to `Winter`
74. `ke-` to `#` 
75. `Volume ke-` to `Volume`
76. `hlm` to `p.` 
77. `Terjemahan dari:` to `Translated from:` 
78. `Ed ke-` to `Ed.`
79. `ulasan` to `review`
80. `komunikasi singkat` to `personal communication`

You can manually verify these changes in the lines specified below.

The `ipb_en.csl` file below has been reformats using [The CSL Style Formatter](https://formatter.citationstyles.org/) following Citation Style Language (CSL) styles standards and can be used to prepare this style for submission.

Formatting changes include:
* Standard indentation
* Escaping of certain characters that are hard to identify by eye, like non-breaking spaces and the various dashes
* Standard ordering the child elements of `<info/>`
* Standard ordering of attributes on `<style/>` and `<link/>` elements

![Screenshot 2024-05-21 133203](https://github.com/auriza/csl-ipb/assets/722584/4e10a54c-9212-4d79-b109-c3b05b72ca0f)
